### PR TITLE
Feat: 토큰 갱신 및 재로그인 기능 구현

### DIFF
--- a/Tidify/Targets/TidifyData/Sources/Extension/MoyaProvider+.swift
+++ b/Tidify/Targets/TidifyData/Sources/Extension/MoyaProvider+.swift
@@ -56,13 +56,14 @@ public extension MoyaProvider {
           KeyChain.save(key: .accessToken, data: accessTokenData)
           completion()
         } else {
-          //TODO: refresh-token 만료되었을 때 재로그인 유도, 추후 테스트 필요!
           KeyChain.deleteAll()
           guard let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
                 let firstWindow = firstScene.windows.first
           else { return }
           
           let navigationController: UINavigationController = .init(nibName: nil, bundle: nil)
+          PresentationAssembly(navigationController: navigationController)
+            .assemble(container: DIContainer.shared)
           firstWindow.rootViewController = navigationController
           
           let mainCoordinator: DefaultMainCoordinator = .init(

--- a/Tidify/Targets/TidifyData/Sources/Extension/MoyaProvider+.swift
+++ b/Tidify/Targets/TidifyData/Sources/Extension/MoyaProvider+.swift
@@ -48,10 +48,10 @@ public extension MoyaProvider {
     updateService.request(.updateToken) { result in
       switch result {
       case .success(let response):
-        let responseData = try? response.map(UserTokenDTO.self)
+        guard let responseData = try? response.map(UserTokenDTO.self) else { return }
         
-        if responseData?.response.code == "N200" {
-          guard let accessTokenData = responseData?.accessToken.data(using: .utf8) else { return }
+        if responseData.response.code == "N200" {
+          guard let accessTokenData = responseData.accessToken.data(using: .utf8) else { return }
           KeyChain.save(key: .accessToken, data: accessTokenData)
           completion()
         } else {

--- a/Tidify/Targets/TidifyData/Sources/Extension/MoyaProvider+.swift
+++ b/Tidify/Targets/TidifyData/Sources/Extension/MoyaProvider+.swift
@@ -1,0 +1,78 @@
+//
+//  Repositoriable.swift
+//  TidifyCore
+//
+//  Created by 한상진 on 2022/11/06.
+//  Copyright © 2022 Tidify. All rights reserved.
+//
+
+import TidifyCore
+import TidifyDomain
+import TidifyPresentation
+import UIKit
+
+import Moya
+import RxSwift
+
+enum RequestError: Error {
+  case error
+}
+
+public extension MoyaProvider {
+  func request(_ target: Target) -> Single<Response> {
+    let requestResponse = Single<Response>.create { [weak self] single in
+      let cancellableToken = self?.request(target, callbackQueue: nil, progress: nil) { result in
+        switch result {
+        case let .success(response):
+          guard let responseData = try? response.map(DefaultResponse.self) else { return }
+          guard responseData.apiResponse.code != "N200" else { single(.success(response)); break }
+          
+          self?.updateToken {
+            single(.failure(RequestError.error))
+          }
+        case let .failure(error):
+          single(.failure(error))
+        }
+      }
+      
+      return Disposables.create {
+        cancellableToken?.cancel()
+      }
+    }
+    
+    return requestResponse.retry(2)
+  }
+  
+  private func updateToken(completion: @escaping () -> Void) {
+    let updateService = MoyaProvider<AuthService>(plugins: [NetworkPlugin()])
+    
+    updateService.request(.updateToken) { result in
+      switch result {
+      case .success(let response):
+        let responseData = try? response.map(UserTokenDTO.self)
+        
+        if responseData?.response.code == "N200" {
+          guard let accessTokenData = responseData?.accessToken.data(using: .utf8) else { return }
+          KeyChain.save(key: .accessToken, data: accessTokenData)
+          completion()
+        } else {
+          //TODO: refresh-token 만료되었을 때 재로그인 유도, 추후 테스트 필요!
+          KeyChain.deleteAll()
+          guard let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                let firstWindow = firstScene.windows.first
+          else { return }
+          
+          let navigationController: UINavigationController = .init(nibName: nil, bundle: nil)
+          firstWindow.rootViewController = navigationController
+          
+          let mainCoordinator: DefaultMainCoordinator = .init(
+            navigationController: navigationController
+          )
+          mainCoordinator.start()
+        }
+      case let .failure(error):
+        print("❌ \(#file) - \(#line): \(#function) - Fail: \(error.localizedDescription)")
+      }
+    }
+  }
+}

--- a/Tidify/Targets/TidifyData/Sources/Extension/MoyaProvider+.swift
+++ b/Tidify/Targets/TidifyData/Sources/Extension/MoyaProvider+.swift
@@ -20,7 +20,7 @@ enum RequestError: Error {
 
 public extension MoyaProvider {
   func request(_ target: Target) -> Single<Response> {
-    let requestResponse = Single<Response>.create { [weak self] single in
+    Single<Response>.create { [weak self] single in
       let cancellableToken = self?.request(target, callbackQueue: nil, progress: nil) { result in
         switch result {
         case let .success(response):
@@ -39,8 +39,7 @@ public extension MoyaProvider {
         cancellableToken?.cancel()
       }
     }
-    
-    return requestResponse.retry(2)
+    .retry(2)
   }
   
   private func updateToken(completion: @escaping () -> Void) {

--- a/Tidify/Targets/TidifyData/Sources/Extension/MoyaProvider+.swift
+++ b/Tidify/Targets/TidifyData/Sources/Extension/MoyaProvider+.swift
@@ -43,7 +43,7 @@ public extension MoyaProvider {
   }
   
   private func updateToken(completion: @escaping () -> Void) {
-    let updateService = MoyaProvider<AuthService>(plugins: [NetworkPlugin()])
+    let updateService: MoyaProvider<AuthService> = .init(plugins: [NetworkPlugin()])
     
     updateService.request(.updateToken) { result in
       switch result {

--- a/Tidify/Targets/TidifyData/Sources/Repositories/DefaultBookmarkRepository.swift
+++ b/Tidify/Targets/TidifyData/Sources/Repositories/DefaultBookmarkRepository.swift
@@ -14,33 +14,33 @@ import RxSwift
 public struct DefaultBookmarkRepository: BookmarkRepository {
 
   // MARK: - Properties
-  private let bookmarkServicce: MoyaProvider<BookmarkService>
+  private let bookmarkService: MoyaProvider<BookmarkService>
 
   // MARK: - Initializer
   public init() {
-    self.bookmarkServicce = .init(plugins: [NetworkPlugin()])
+    self.bookmarkService = .init(plugins: [NetworkPlugin()])
   }
 
   // MARK: - Methods
   public func fetchBookmarkList() -> Single<[Bookmark]> {
-    return bookmarkServicce.request(.fetchBookmarkList())
+    return bookmarkService.request(.fetchBookmarkList())
       .map(BookmarkListDTO.self)
       .map { $0.toDomain() }
   }
 
   public func createBookmark(requestDTO: BookmarkRequestDTO) -> Single<Bookmark> {
-    return bookmarkServicce.request(.createBookmark(requestDTO))
+    return bookmarkService.request(.createBookmark(requestDTO))
       .map(BookmarkDTO.self)
       .map { $0.toDomaion() }
   }
 
   public func deleteBookmark(bookmarkID: Int) -> Single<Void> {
-    return bookmarkServicce.request(.deleteBookmark(bookmarkID: bookmarkID))
+    return bookmarkService.request(.deleteBookmark(bookmarkID: bookmarkID))
       .map { _ in }
   }
 
   public func updateBookmark(bookmarkID: Int, requestDTO: BookmarkRequestDTO) -> Single<Void> {
-    return bookmarkServicce.request(.updateBookmark(
+    return bookmarkService.request(.updateBookmark(
       bookmarkID: bookmarkID,
       requestDTO: requestDTO)
     )

--- a/Tidify/Targets/TidifyData/Sources/Repositories/DefaultBookmarkRepository.swift
+++ b/Tidify/Targets/TidifyData/Sources/Repositories/DefaultBookmarkRepository.swift
@@ -23,24 +23,24 @@ public struct DefaultBookmarkRepository: BookmarkRepository {
 
   // MARK: - Methods
   public func fetchBookmarkList() -> Single<[Bookmark]> {
-    return bookmarkServicce.rx.request(.fetchBookmarkList())
+    return bookmarkServicce.request(.fetchBookmarkList())
       .map(BookmarkListDTO.self)
       .map { $0.toDomain() }
   }
 
   public func createBookmark(requestDTO: BookmarkRequestDTO) -> Single<Bookmark> {
-    return bookmarkServicce.rx.request(.createBookmark(requestDTO))
+    return bookmarkServicce.request(.createBookmark(requestDTO))
       .map(BookmarkDTO.self)
       .map { $0.toDomaion() }
   }
 
   public func deleteBookmark(bookmarkID: Int) -> Single<Void> {
-    return bookmarkServicce.rx.request(.deleteBookmark(bookmarkID: bookmarkID))
+    return bookmarkServicce.request(.deleteBookmark(bookmarkID: bookmarkID))
       .map { _ in }
   }
 
   public func updateBookmark(bookmarkID: Int, requestDTO: BookmarkRequestDTO) -> Single<Void> {
-    return bookmarkServicce.rx.request(.updateBookmark(
+    return bookmarkServicce.request(.updateBookmark(
       bookmarkID: bookmarkID,
       requestDTO: requestDTO)
     )

--- a/Tidify/Targets/TidifyData/Sources/Repositories/DefaultFolderRepository.swift
+++ b/Tidify/Targets/TidifyData/Sources/Repositories/DefaultFolderRepository.swift
@@ -23,17 +23,17 @@ public struct DefaultFolderRepository: FolderRepository {
   
   // MARK: - Methods
   public func createFolder(requestDTO: FolderRequestDTO) -> Single<Void> {
-    return folderService.rx.request(.createFolder(requestDTO)).map { _ in }
+    return folderService.request(.createFolder(requestDTO)).map { _ in }
   }
   
   public func fetchFolders() -> Single<[Folder]> {
-    return folderService.rx.request(.fetchFolders())
+    return folderService.request(.fetchFolders())
       .map(FolderListDTO.self)
       .map { $0.toDomain().reversed() }
   }
   
   public func updateFolder(id: Int, requestDTO: FolderRequestDTO) -> Single<Void> {
-    return folderService.rx.request(.updateFolder(
+    return folderService.request(.updateFolder(
       id: id,
       requestDTO: requestDTO)
     )
@@ -41,7 +41,7 @@ public struct DefaultFolderRepository: FolderRepository {
   }
   
   public func deleteFolder(id: Int) -> Single<Void> {
-    return folderService.rx.request(.deleteFolder(id: id))
+    return folderService.request(.deleteFolder(id: id))
       .map { _ in }
   }
 }

--- a/Tidify/Targets/TidifyData/Sources/Repositories/DefaultSearchRepository.swift
+++ b/Tidify/Targets/TidifyData/Sources/Repositories/DefaultSearchRepository.swift
@@ -39,7 +39,7 @@ public struct DefaultSearchRepository: SearchRepository {
       saveQuery(query: query)
     }
 
-    return bookmarkService.rx.request(.fetchBookmarkList(keyword: query))
+    return bookmarkService.request(.fetchBookmarkList(keyword: query))
       .map(BookmarkListDTO.self)
       .map { $0.toDomain() }
   }

--- a/Tidify/Targets/TidifyData/Sources/Repositories/DefaultSignInRepository.swift
+++ b/Tidify/Targets/TidifyData/Sources/Repositories/DefaultSignInRepository.swift
@@ -22,7 +22,7 @@ public struct DefaultSignInRepository: SignInRepository {
 
   // MARK: - Methods
   public func tryAppleLogin(token: String) -> Single<UserToken> {
-    return authService.rx.request(.apple(token: token))
+    return authService.request(.apple(token: token))
       .map(UserTokenDTO.self)
       .map { $0.toDomain() }
   }

--- a/Tidify/Targets/TidifyData/Sources/Response/DefaultResponse.swift
+++ b/Tidify/Targets/TidifyData/Sources/Response/DefaultResponse.swift
@@ -1,0 +1,15 @@
+//
+//  DefaultResponse.swift
+//  TidifyData
+//
+//  Created by 한상진 on 2022/11/07.
+//  Copyright © 2022 Tidify. All rights reserved.
+//
+
+struct DefaultResponse: Decodable {
+  let apiResponse: APIResponse
+  
+  enum CodingKeys: String, CodingKey {
+    case apiResponse = "api_response"
+  }
+}

--- a/Tidify/Targets/TidifyData/Sources/Services/AuthService.swift
+++ b/Tidify/Targets/TidifyData/Sources/Services/AuthService.swift
@@ -13,6 +13,7 @@ import Moya
 
 enum AuthService {
   case apple(token: String)
+  case updateToken
 }
 
 extension AuthService: TargetType {
@@ -21,12 +22,17 @@ extension AuthService: TargetType {
   }
 
   var path: String {
-    let baseRoutePath = "/auth"
-    return baseRoutePath + "/apple"
+    switch self {
+    case .apple: return "/auth/apple"
+    case .updateToken: return "/updateToken"
+    }
   }
 
   var method: Moya.Method {
-    return .post
+    switch self {
+    case .apple: return .post
+    case .updateToken: return .get
+    }
   }
 
   var sampleData: Data {
@@ -38,6 +44,8 @@ extension AuthService: TargetType {
     let encoding: ParameterEncoding
 
     switch self.method {
+    case .get:
+      return .requestPlain
     case .post, .patch, .put:
       encoding = JSONEncoding.default
     default:
@@ -47,16 +55,19 @@ extension AuthService: TargetType {
     return .requestParameters(parameters: requestParameters, encoding: encoding)
   }
 
-  var headers: [String: String]? {
-    return nil
+  var headers: [String : String]? {
+    switch self {
+    case .updateToken:
+      return ["refresh-token": AppProperties.refreshToken]
+    case .apple:
+      return nil
+    }
   }
 
   private var parameters: [String: Any]? {
     switch self {
-    case .apple(let token):
-      return [
-        "id_token": token
-      ]
+    case .apple(let token): return ["id_token": token]
+    case .updateToken: return nil
     }
   }
 }

--- a/Tidify/Targets/TidifyData/Sources/Services/AuthService.swift
+++ b/Tidify/Targets/TidifyData/Sources/Services/AuthService.swift
@@ -24,7 +24,7 @@ extension AuthService: TargetType {
   var path: String {
     switch self {
     case .apple: return "/auth/apple"
-    case .updateToken: return "/updateToken"
+    case .updateToken: return "/signin"
     }
   }
 


### PR DESCRIPTION
### 📌 #137 토큰 갱신 및 재로그인 기능 구현
Closes #137

### 📘 작업 유형

- [x] 신규 기능 추가

<br>

### 📙 작업 내역

> 구현 내용 및 작업 내역을 기재합니다.

- [x] MoyaProvider request 메서드 커스텀
- - Access-Token 만료시 갱신 후 API 재호출 기능 구현
- - Refresh-Token 만료시 로그인 화면으로 이동 기능 구현
- [x] 기존 rx.request로 접근하는 코드들 -> request로 접근하도록 코드 수정

<br>

### 📋 체크리스트

- [x] PR 제목에 Prefix(Feat, Refactor, Fix...etc) 와 작업 내용을 요약하여 기재했는가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

<br>

### 📝 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점으로 없을 경우 제거 이후 PR을 생성합니다.

- API 호출을 했을 때 Access-Token과 Refresh-Token이 모두 만료시 강제로 로그인 화면으로 전환되도록 구현했으나
아무 알림 없이 강제로 이동되는 게 사용자 경험이 좋아보이지 않음 -> Alert창이라도 뜨게 하는 게 좋아보임
-> 논의 후 결정 예정

<br/><br/>
