### PR TITLE
fix: 폴더 삭제 완료 이후 인디케이터가 사라지지 않는 이슈 수정

### DIFF
--- a/Tidify/Targets/TidifyPresentation/Sources/Folder/ViewModel/FolderViewModel.swift
+++ b/Tidify/Targets/TidifyPresentation/Sources/Folder/ViewModel/FolderViewModel.swift
@@ -82,6 +82,7 @@ private extension FolderViewModel {
         state.folders.remove(at: index)
 
         if isLastPage {
+          state.isLoading = false
           return
         }
 


### PR DESCRIPTION
### 📘 작업 유형

- [x] 버그 수정

<br>

### 📙 작업 내역

> 구현 내용 및 작업 내역을 기재합니다.

- [x] 폴더 삭제 완료시 인디케이터가 계속 남아있는 이슈 수정
  - `isLastPage` 값에 따라 분기 진행중 isLoading 값 세팅없이 return을 하여 return 이전에 isLoading 값 적용

<br>

### 📋 체크리스트

- [x] PR 제목에 Prefix(Feat, Refactor, Fix...etc) 와 작업 내용을 요약하여 기재했는가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

<br>